### PR TITLE
Add The Modern promo link

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -245,4 +245,19 @@ body {
   .product-card.hffs .product-tagline {
     color: rgba(255, 255, 255, 0.8);
   }
+
+  /* The Modern promo */
+  .the-modern-promo {
+    @apply mt-8 text-sm;
+    color: #6b7280;
+  }
+
+  .the-modern-promo a {
+    @apply underline;
+    color: #c4784a;
+  }
+
+  .the-modern-promo a:hover {
+    color: #a5623a;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -62,4 +62,9 @@ layout: default
       </div>
     </a>
   </div>
+
+  <div class="the-modern-promo">
+    <span>Also building community at</span>
+    <a href="https://themodernhq.com/" target="_blank">The Modern</a>.
+  </div>
 </section>


### PR DESCRIPTION
Add a subtle promotional link to The Modern below the product cards. Uses The Modern's terracotta brand color for the underlined link.

Changes:
- Add "Also building community at The Modern." text below products
- Style with minimal, understated design matching The Modern's visual identity