### PR TITLE
Add CI build workflow for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.1'
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Cache Jekyll build
+        uses: actions/cache@v4
+        with:
+          path: .jekyll-cache
+          key: jekyll-${{ hashFiles('**/*.html', '**/*.md', '_config.yml') }}
+          restore-keys: jekyll-
+
+      - name: Build Jekyll site
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ See it live at [merimerimeri.com](https://merimerimeri.com).
 
 `bundle exec jekyll serve`
 
+## CI
+
+Every pull request (and push to non-main branches) runs a build check via GitHub Actions to catch errors before merging. The workflow installs Ruby/Node dependencies and runs:
+
+```bash
+bundle exec jekyll build
+```
+
+To run the same check locally:
+
+```bash
+bundle install && npm install
+JEKYLL_ENV=production bundle exec jekyll build
+```
+
 ## Deployment
 
-Pushing to `main` triggers a GitHub Actions workflow that builds the Jekyll site and deploys it to Cloudflare Pages.
+Pushing to `main` triggers a separate GitHub Actions workflow that builds the Jekyll site and deploys it to Cloudflare Pages.


### PR DESCRIPTION
## Summary
- Adds a lightweight CI workflow (`.github/workflows/ci.yml`) that runs on pull requests and pushes to non-main branches
- Builds the Jekyll site with the same Ruby/Node setup as the deploy workflow — catches build errors before merging
- No deployment, no secrets required
- Updates README with a CI section explaining what runs and how to reproduce locally

## Test plan
- [ ] CI workflow runs on this PR and passes
- [ ] Verify no deployment is triggered
- [ ] Confirm README CI section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)