### PR TITLE
Improve CI: add path filters and status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches-ignore:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.1'
+          bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Cache Jekyll build
+        uses: actions/cache@v4
+        with:
+          path: .jekyll-cache
+          key: jekyll-${{ hashFiles('**/*.html', '**/*.md', '_config.yml') }}
+          restore-keys: jekyll-
+
+      - name: Build Jekyll site
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,39 @@ name: CI
 
 on:
   pull_request:
+    paths:
+      - '_config.yml'
+      - '_includes/**'
+      - '_layouts/**'
+      - '_posts/**'
+      - '_archive/**'
+      - 'assets/**'
+      - 'blog/**'
+      - 'css/**'
+      - '*.html'
+      - 'Gemfile*'
+      - 'package*.json'
+      - 'tailwind.config.js'
+      - 'postcss.config.js'
+      - '.github/workflows/ci.yml'
   push:
     branches-ignore:
       - main
+    paths:
+      - '_config.yml'
+      - '_includes/**'
+      - '_layouts/**'
+      - '_posts/**'
+      - '_archive/**'
+      - 'assets/**'
+      - 'blog/**'
+      - 'css/**'
+      - '*.html'
+      - 'Gemfile*'
+      - 'package*.json'
+      - 'tailwind.config.js'
+      - 'postcss.config.js'
+      - '.github/workflows/ci.yml'
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ See it live at [merimerimeri.com](https://merimerimeri.com).
 
 `bundle exec jekyll serve`
 
+## CI
+
+Every pull request (and push to non-main branches) runs a build check via GitHub Actions to catch errors before merging. The workflow installs Ruby/Node dependencies and runs:
+
+```bash
+bundle exec jekyll build
+```
+
+To run the same check locally:
+
+```bash
+bundle install && npm install
+JEKYLL_ENV=production bundle exec jekyll build
+```
+
 ## Deployment
 
-Pushing to `main` triggers a GitHub Actions workflow that builds the Jekyll site and deploys it to Cloudflare Pages.
+Pushing to `main` triggers a separate GitHub Actions workflow that builds the Jekyll site and deploys it to Cloudflare Pages.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # merimerimeri.com
 
+[![CI](https://github.com/MeriMeriMeri/merimerimeri.com/actions/workflows/ci.yml/badge.svg)](https://github.com/MeriMeriMeri/merimerimeri.com/actions/workflows/ci.yml)
+
 Website for MeriMeriMeri Software — a studio that builds focused, delightful software products.
 
 See it live at [merimerimeri.com](https://merimerimeri.com).


### PR DESCRIPTION
## Summary
- Add `paths` filters to CI workflow so it skips docs-only changes (README, LICENSE, etc.), matching the deploy workflow's pattern
- Add CI status badge to README

## Test plan
- [ ] Verify CI runs on this PR (touches workflow file, so it should trigger)
- [ ] Confirm badge renders correctly on the README

🤖 Generated with [Claude Code](https://claude.com/claude-code)