### PR TITLE
Add Jenkinsfile for local build/deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,58 @@
+pipeline {
+    agent none
+    environment {
+        JEKYLL_ENV = 'production'
+        GIT_SSH_COMMAND = 'ssh -o StrictHostKeyChecking=no'
+    }
+    options {
+        skipDefaultCheckout()
+    }
+    stages {
+        stage('Checkout') {
+            agent any
+            steps {
+                checkout([
+                    $class: 'GitSCM',
+                    branches: [[name: '*/main']],
+                    userRemoteConfigs: [[
+                        url: 'git@github.com:merimerimeri/merimerimeri.com.git',
+                        credentialsId: 'github-ssh-key'
+                    ]]
+                ])
+                stash name: 'source'
+            }
+        }
+        stage('Build') {
+            agent {
+                docker {
+                    image 'ruby:3.3.4'
+                    args '-u root'
+                }
+            }
+            steps {
+                unstash 'source'
+                sh 'curl -fsSL https://deb.nodesource.com/setup_20.x | bash -'
+                sh 'apt-get install -y nodejs'
+                sh 'bundle install'
+                sh 'npm ci'
+                sh 'bundle exec jekyll build'
+                stash includes: '_site/**', name: 'site'
+            }
+        }
+        stage('Deploy') {
+            agent {
+                docker {
+                    image 'node:20'
+                }
+            }
+            environment {
+                CLOUDFLARE_API_TOKEN = credentials('cloudflare-api-token')
+                CLOUDFLARE_ACCOUNT_ID = credentials('cloudflare-account-id')
+            }
+            steps {
+                unstash 'site'
+                sh 'npx wrangler pages deploy _site --project-name=merimerimeri'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a declarative Jenkins pipeline using Docker agents (`ruby:3.3.4` for build, `node:20` for deploy)
- Checks out repo via SSH with `github-ssh-key` credential
- Builds Jekyll site and deploys to Cloudflare Pages via Wrangler
- GitHub Actions workflow remains untouched as a fallback

## Setup required
1. Add SSH private key as Jenkins credential (ID: `github-ssh-key`)
2. Add Cloudflare credentials (`cloudflare-api-token`, `cloudflare-account-id`)
3. Create pipeline job pointing to this repo's `Jenkinsfile`
4. Ensure Docker socket is mounted in the Jenkins container

## Test plan
- [ ] Verify Jenkins can check out the repo via SSH
- [ ] Confirm Docker agents pull and run correctly
- [ ] Run a full build and check `_site/` output
- [ ] Deploy to Cloudflare Pages and verify site updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)